### PR TITLE
Use compile-time constant definition of is_rp2350 to determine the execctrl bit layout.

### DIFF
--- a/ports/rp2/modrp2.c
+++ b/ports/rp2/modrp2.c
@@ -95,6 +95,17 @@ static const mp_rom_map_elem_t rp2_module_globals_table[] = {
     // Deprecated (use network.country instead).
     { MP_ROM_QSTR(MP_QSTR_country),             MP_ROM_PTR(&mod_network_country_obj) },
     #endif
+
+    #if PICO_RP2040
+    { MP_ROM_QSTR(MP_QSTR_is_rp2040),           MP_ROM_TRUE },
+    #else
+    { MP_ROM_QSTR(MP_QSTR_is_rp2040),           MP_ROM_FALSE },
+    #endif
+    #if PICO_RP2350
+    { MP_ROM_QSTR(MP_QSTR_is_rp2350),           MP_ROM_TRUE },
+    #else
+    { MP_ROM_QSTR(MP_QSTR_is_rp2350),           MP_ROM_FALSE },
+    #endif
 };
 static MP_DEFINE_CONST_DICT(rp2_module_globals, rp2_module_globals_table);
 

--- a/ports/rp2/modules/rp2.py
+++ b/ports/rp2/modules/rp2.py
@@ -42,7 +42,7 @@ class PIOASMEmit:
         from array import array
 
         self.labels = {}
-        if 'RP2350' in sys.implementation._machine:
+        if is_rp2350:
             execctrl = side_pindir << 29 | (status_sel & 0x3) << 5 | (status_n & 0x1F)
         else:
             execctrl = side_pindir << 29 | (status_sel & 0x1) << 4 | (status_n & 0x0F)


### PR DESCRIPTION
Just a quick tweak to your PR to have it use compile-time platform data instead of making a runtime runaround with strings.